### PR TITLE
chore: add passkey field in entropy

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openfort/shield-js",
-  "version": "0.1.17",
+  "version": "0.1.18",
   "description": "",
   "author": "Openfort",
   "repository": {

--- a/src/models/Share.ts
+++ b/src/models/Share.ts
@@ -10,6 +10,7 @@ export enum entropy {
     none = "none",
     user = "user",
     project = "project",
+    passkey = "passkey",
 }
 
 export interface EncryptionParameters {


### PR DESCRIPTION
Add passkey value to shieldJS, otherwise it'll default to none when sending the secret