### PR TITLE
fix: resolve Dependabot security alerts

### DIFF
--- a/.changeset/green-hounds-repair.md
+++ b/.changeset/green-hounds-repair.md
@@ -1,0 +1,5 @@
+---
+"@openfort/shield-js": patch
+---
+
+update deps

--- a/package.json
+++ b/package.json
@@ -35,8 +35,13 @@
     "typescript": "^5.4.3"
   },
   "dependencies": {
-    "axios": "1.13.6",
+    "axios": "1.15.0",
     "axios-retry": "4.5.0"
+  },
+  "pnpm": {
+    "overrides": {
+      "picomatch": ">=2.3.2"
+    }
   },
   "packageManager": "pnpm@10.19.0"
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -4,16 +4,19 @@ settings:
   autoInstallPeers: true
   excludeLinksFromLockfile: false
 
+overrides:
+  picomatch: '>=2.3.2'
+
 importers:
 
   .:
     dependencies:
       axios:
-        specifier: 1.13.6
-        version: 1.13.6
+        specifier: 1.15.0
+        version: 1.15.0
       axios-retry:
         specifier: 4.5.0
-        version: 4.5.0(axios@1.13.6)
+        version: 4.5.0(axios@1.15.0)
     devDependencies:
       '@biomejs/biome':
         specifier: ^2.2.4
@@ -204,8 +207,8 @@ packages:
     peerDependencies:
       axios: 0.x || 1.x
 
-  axios@1.13.6:
-    resolution: {integrity: sha512-ChTCHMouEe2kn713WHbQGcuYrr6fXTBiu460OTwWrWob16g1bXn4vtz07Ope7ewMozJAnEquLk5lWQWtBig9DQ==}
+  axios@1.15.0:
+    resolution: {integrity: sha512-wWyJDlAatxk30ZJer+GeCWS209sA42X+N5jU2jy6oHTp7ufw8uzUTVFBX9+wTfAlhiJXGS0Bq7X6efruWjuK9Q==}
 
   better-path-resolve@1.0.0:
     resolution: {integrity: sha512-pbnl5XzGBdrFU/wT4jqmJVPn2B6UHPBOhzMQkY/SPUPB6QtUXtmBHBIwCbXJol93mOpGMnQyP/+BB19q04xj7g==}
@@ -490,9 +493,9 @@ packages:
   picocolors@1.1.1:
     resolution: {integrity: sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==}
 
-  picomatch@2.3.1:
-    resolution: {integrity: sha512-JU3teHTNjmE2VCGFzuY8EXzCDVwEqB2a8fsIvwaStHhAWJEeVd1o1QD80CU6+ZdEXXSLbSsuLwJjkCBWqRQUVA==}
-    engines: {node: '>=8.6'}
+  picomatch@4.0.4:
+    resolution: {integrity: sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==}
+    engines: {node: '>=12'}
 
   pify@4.0.1:
     resolution: {integrity: sha512-uB80kBFb/tfd68bVleG9T5GGsGPjJrLAUpR5PZIrhBnIaRTQRjqdJSsIKkOP6OAIFbj7GOrcudc5pNjZ+geV2g==}
@@ -503,8 +506,9 @@ packages:
     engines: {node: '>=10.13.0'}
     hasBin: true
 
-  proxy-from-env@1.1.0:
-    resolution: {integrity: sha512-D+zkORCbA9f1tdWRK0RaCR3GPv50cMxcrz4X8k5LTSUD1Dkw47mKJEZQNunItRTkWwgtaUSo1RVFRIG9ZXiFYg==}
+  proxy-from-env@2.1.0:
+    resolution: {integrity: sha512-cJ+oHTW1VAEa8cJslgmUZrc+sjRKgAKl3Zyse6+PV38hZe/V6Z14TbCuXcan9F9ghlz4QrFr2c92TNF82UkYHA==}
+    engines: {node: '>=10'}
 
   quansync@0.2.11:
     resolution: {integrity: sha512-AifT7QEbW9Nri4tAwR5M/uzpBuqfZf+zwaEM/QkzEjj7NBuFD2rBuy0K3dE+8wltbezDV7JMA0WfnCPYRSYbXA==}
@@ -843,16 +847,16 @@ snapshots:
 
   asynckit@0.4.0: {}
 
-  axios-retry@4.5.0(axios@1.13.6):
+  axios-retry@4.5.0(axios@1.15.0):
     dependencies:
-      axios: 1.13.6
+      axios: 1.15.0
       is-retry-allowed: 2.2.0
 
-  axios@1.13.6:
+  axios@1.15.0:
     dependencies:
       follow-redirects: 1.15.11
       form-data: 4.0.5
-      proxy-from-env: 1.1.0
+      proxy-from-env: 2.1.0
     transitivePeerDependencies:
       - debug
 
@@ -1067,7 +1071,7 @@ snapshots:
   micromatch@4.0.8:
     dependencies:
       braces: 3.0.3
-      picomatch: 2.3.1
+      picomatch: 4.0.4
 
   mime-db@1.52.0: {}
 
@@ -1111,13 +1115,13 @@ snapshots:
 
   picocolors@1.1.1: {}
 
-  picomatch@2.3.1: {}
+  picomatch@4.0.4: {}
 
   pify@4.0.1: {}
 
   prettier@2.8.8: {}
 
-  proxy-from-env@1.1.0: {}
+  proxy-from-env@2.1.0: {}
 
   quansync@0.2.11: {}
 


### PR DESCRIPTION
## Summary

- Update axios 1.13.6 → 1.15.0 to fix 2 critical vulnerabilities (SSRF via NO_PROXY bypass, cloud metadata exfiltration via header injection)
- Add pnpm override for picomatch >=2.3.2 to fix 1 high + 1 moderate vulnerability (ReDoS, method injection) in transitive dep via @changesets/cli

## Resolved alerts

| # | Package | Severity | Advisory |
|---|---------|----------|----------|
| 13, 14 | axios | Critical | GHSA-3p68-rc4w-qgx5, GHSA-fvcv-3m26-pcqx |
| 10 | picomatch | High | GHSA-c2c7-rcm5-vvqj |
| 11 | picomatch | Moderate | GHSA-3v7f-55p6-f55p |

## Verification

- `pnpm audit` returns 0 vulnerabilities
- `pnpm build` passes